### PR TITLE
Fix project name in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "modal-window-practice",
+  "name": "modal-window-animation-practice",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,


### PR DESCRIPTION
## Summary
- rename the project in `package-lock.json` to `modal-window-animation-practice`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68837b91a0048324b78ab6a52ebcf1aa